### PR TITLE
Build using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+
+FROM maven as builder
+RUN mkdir /build
+WORKDIR /build
+RUN git clone https://github.com/rstorey/veraPDF-rest.git
+RUN cd veraPDF-rest && git checkout integration && mvn clean package
+
+
+FROM openjdk:8-jre
+
+ENV VERAPDF_REST_VERSION=0.1.0-SNAPSHOT
+
+# Since this is a running network service we'll create an unprivileged account
+# which will be used to perform the rest of the work and run the actual service:
+RUN useradd --system --user-group --home-dir=/opt/verapdf-rest verapdf-rest
+USER verapdf-rest
+
+WORKDIR /opt/verapdf-rest
+COPY --from=builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/
+
+EXPOSE 8080
+ENTRYPOINT java -jar /opt/verapdf-rest/verapdf-rest-${VERAPDF_REST_VERSION}.jar server

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,20 @@ RUN git clone https://github.com/rstorey/veraPDF-rest.git
 RUN cd veraPDF-rest && git checkout integration && mvn clean package
 
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV VERAPDF_REST_VERSION=0.1.0-SNAPSHOT
 
 # Since this is a running network service we'll create an unprivileged account
 # which will be used to perform the rest of the work and run the actual service:
-RUN useradd --system --user-group --home-dir=/opt/verapdf-rest verapdf-rest
-USER verapdf-rest
 
+# Debian:
+# RUN useradd --system --user-group --home-dir=/opt/verapdf-rest verapdf-rest
+# Alpine / Busybox:
+RUN install -d -o root -g root -m 755 /opt && adduser -h /opt/verapdf-rest -S verapdf-rest
+USER verapdf-rest
 WORKDIR /opt/verapdf-rest
+
 COPY --from=builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/
 
 EXPOSE 8080


### PR DESCRIPTION
This uses a Docker multi-stage build so the final container image which
may be deployed does not require more than the base OpenJDK JRE without
the entire build tool-chain.

Tested lightly:

```
docker build -t verapdf-rest:latest . && docker run -p 8080:8080 verapdf-rest:latest
```

The built `verapdf-rest` image is notable smaller than just the base Maven image even before you consider the downloaded dependencies so the multi-stage build is definitely worthwhile: 

```
cadams@ganymede:~ $ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
verapdf-rest        latest              c3c2a52a7bc0        5 minutes ago       297MB
maven               latest              88714384d642        11 days ago         749MB
```

Using the Alpine-based OpenJRE images provides a further hefty size reduction and we don't seem to be using anything which would be easier on Ubuntu:

```
verapdf-rest        latest              c69af6445b35        31 seconds ago      103MB
```